### PR TITLE
Prevent fallback login from overwriting existing passwords

### DIFF
--- a/app.js
+++ b/app.js
@@ -452,12 +452,18 @@ function handleLogin(evt) {
       saveState();
       user = state.users.find(u => u.username === username && u.password === password);
     } else if (fallback && existing) {
-      existing.password = fallback.password;
-      existing.role = existing.role || fallback.role;
-      existing.fullName = existing.fullName || fallback.fullName;
-      existing.updatedAt = new Date().toISOString();
-      saveState();
-      user = state.users.find(u => u.username === username && u.password === password);
+      const updates = {};
+      if (!existing.role && fallback.role) {
+        updates.role = fallback.role;
+      }
+      if (!existing.fullName && fallback.fullName) {
+        updates.fullName = fallback.fullName;
+      }
+      const hasUpdates = Object.keys(updates).length > 0;
+      if (hasUpdates) {
+        Object.assign(existing, updates, { updatedAt: new Date().toISOString() });
+        saveState();
+      }
     }
   }
   withLoading('Đang kiểm tra tài khoản...', () => {


### PR DESCRIPTION
## Summary
- stop the default credential fallback from overwriting the password of an existing user
- limit the fallback to backfilling missing profile metadata so administrators retain their chosen credentials

## Testing
- node --check app.js *(fails: SyntaxError from pre-existing stray text in app.js around lines 60-70)*

------
https://chatgpt.com/codex/tasks/task_e_68e714b7c43883338ea35455b8b740c9